### PR TITLE
Fix/add boto3 to make Bedrock examples run out of the box

### DIFF
--- a/README.md
+++ b/README.md
@@ -42,7 +42,9 @@ The code agent needs a controlled and isolated environment to run the code it ge
    MODEL="gemini/gemini-2.0-flash"
    ```
 
-   For other model providers, refer to the [LiteLLM documentation](https://docs.litellm.ai/docs/providers). Note that coding agents require powerful LLMs, such as Claude 3.7 or Gemini 2.0 Flash. While you can use this code with less powerful models, the results might not be great.
+   For other model providers, refer to the [LiteLLM documentation](https://docs.litellm.ai/docs/providers). You might have to add additional dependencies for a given model provider, which are mentioned in the LiteLLM docs. You can add them using `uv add <your-python-package>`. For example, Bedrock models require `boto3`, which has already been added.
+   
+   Note that coding agents require powerful LLMs, such as Claude 3.7 Sonnet, Amazon Nova Pro, or Gemini 2.0 Flash. While you can use this code with less powerful models, the results might not be great.
 
 4. Run the example:
    ```bash

--- a/README.md
+++ b/README.md
@@ -42,7 +42,7 @@ The code agent needs a controlled and isolated environment to run the code it ge
    MODEL="gemini/gemini-2.0-flash"
    ```
 
-   For other model providers, refer to the [LiteLLM documentation](https://docs.litellm.ai/docs/providers). You might have to add additional dependencies for a given model provider, which are mentioned in the LiteLLM docs. You can add them using `uv add <your-python-package>`. For example, Bedrock models require `boto3`, which has already been added.
+   For other model providers, refer to the [LiteLLM documentation](https://docs.litellm.ai/docs/providers). You might have to add additional dependencies for a given model provider, which are mentioned in the LiteLLM docs. You can add them using `uv add <your-python-package>`. For example, Bedrock models require `boto3`, which has already been added. If you don't use AWS-provided models you can also remove `boto3`.
    
    Note that coding agents require powerful LLMs, such as Claude 3.7 Sonnet, Amazon Nova Pro, or Gemini 2.0 Flash. While you can use this code with less powerful models, the results might not be great.
 

--- a/README.md
+++ b/README.md
@@ -24,7 +24,7 @@ The code agent needs a controlled and isolated environment to run the code it ge
    
    The repo uses [LiteLLM](https://docs.litellm.ai/) to support a unified interface across all model providers. Create a `.env` file in the `minimal-agent` folder and add the `MODEL` environment variable with the name of the model as specified on LiteLLM, along with the credentials for the corresponding provider.
    
-   Example for AWS Bedrock:
+   Example for AWS Bedrock (*):
    ```bash
    # AWS Bedrock: https://docs.litellm.ai/docs/providers/bedrock
    AWS_ACCESS_KEY_ID=<YOUR-AWS-ACCESS-KEY-ID>
@@ -50,6 +50,8 @@ The code agent needs a controlled and isolated environment to run the code it ge
    ```bash
    uv run run_agent.py
    ```
+
+(*) Note that there are better [ways to authenticate](https://boto3.amazonaws.com/v1/documentation/api/latest/guide/credentials.html#credentials) with AWS than access keys that are also supported by LiteLLM through boto3. The method above was mentioned because it is the first one mentioned on LiteLLM and provides consistency across providers.
 
 ### Usage Example
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -5,6 +5,7 @@ description = "Add your description here"
 readme = "README.md"
 requires-python = ">=3.12"
 dependencies = [
+    "boto3>=1.37.30",
     "duckduckgo-search>=7.5.1",
     "litellm>=1.61.11",
     "markdownify>=1.1.0",

--- a/uv.lock
+++ b/uv.lock
@@ -117,6 +117,34 @@ wheels = [
 ]
 
 [[package]]
+name = "boto3"
+version = "1.37.30"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "botocore" },
+    { name = "jmespath" },
+    { name = "s3transfer" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/f0/4b/fc19e5b08f5871ebc92a5bb8919133245bf63ab4e985b91e00ff78cd0905/boto3-1.37.30.tar.gz", hash = "sha256:beea13db5a5f5eaacecfa905cd1e4e933c13802f776198264eef229d6dffcc42", size = 111380 }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/28/3a/072a196ee038e859a6bdd52e374533c722e8b943c9a52c673dab70976d98/boto3-1.37.30-py3-none-any.whl", hash = "sha256:c75d78013eb43b354662cbd5f30bf537ab06641d3ed37aaad6fcf55a529d2991", size = 139560 },
+]
+
+[[package]]
+name = "botocore"
+version = "1.37.30"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "jmespath" },
+    { name = "python-dateutil" },
+    { name = "urllib3" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/49/e7/29af47eb173faaeef3daabcc3e94bd8b6c1d87e1ba8eef1c6a18827b9cee/botocore-1.37.30.tar.gz", hash = "sha256:2f43b61e0231abbb4fbe8917acb1af98cb83dbab8c264c0d1f5ca0f16fdbf219", size = 13810655 }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/d9/85/cef0fdbd17f09cddc97c6b3182b099e2583ca77caec76f8a09f76794266e/botocore-1.37.30-py3-none-any.whl", hash = "sha256:d8ca899962d2079acd52483581f607322513910337a69bdae697766404b85b7d", size = 13476760 },
+]
+
+[[package]]
 name = "certifi"
 version = "2025.1.31"
 source = { registry = "https://pypi.org/simple" }
@@ -385,6 +413,15 @@ wheels = [
 ]
 
 [[package]]
+name = "jmespath"
+version = "1.0.1"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/00/2a/e867e8531cf3e36b41201936b7fa7ba7b5702dbef42922193f05c8976cd6/jmespath-1.0.1.tar.gz", hash = "sha256:90261b206d6defd58fdd5e85f478bf633a2901798906be2ad389150c5c60edbe", size = 25843 }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/31/b4/b9b800c45527aadd64d5b442f9b932b00648617eb5d63d2c7a6587b7cafc/jmespath-1.0.1-py3-none-any.whl", hash = "sha256:02e2e4cc71b5bcab88332eebf907519190dd9e6e82107fa7f83b1003a6252980", size = 20256 },
+]
+
+[[package]]
 name = "jsonschema"
 version = "4.23.0"
 source = { registry = "https://pypi.org/simple" }
@@ -552,6 +589,7 @@ name = "minimal-agent"
 version = "0.1.0"
 source = { editable = "." }
 dependencies = [
+    { name = "boto3" },
     { name = "duckduckgo-search" },
     { name = "litellm" },
     { name = "markdownify" },
@@ -563,6 +601,7 @@ dependencies = [
 
 [package.metadata]
 requires-dist = [
+    { name = "boto3", specifier = ">=1.37.30" },
     { name = "duckduckgo-search", specifier = ">=7.5.1" },
     { name = "litellm", specifier = ">=1.61.11" },
     { name = "markdownify", specifier = ">=1.1.0" },
@@ -1065,6 +1104,18 @@ wheels = [
     { url = "https://files.pythonhosted.org/packages/2f/f1/3e44c9874899647627e02bca8b200eb28b4a52286164c43fdf0d50904fe9/rpds_py-0.23.0-cp313-cp313t-musllinux_1_2_x86_64.whl", hash = "sha256:312981d4da5dc463baeca3ba23a3e74dc7a48a4500d267566d8e9c0680ac54c6", size = 555083 },
     { url = "https://files.pythonhosted.org/packages/23/e2/4894cf732611987c3cee18de8ff087994291a4f7bcd42af2d0418e4d0cdf/rpds_py-0.23.0-cp313-cp313t-win32.whl", hash = "sha256:ce1c4277d7f235faa2f31f1aad82e3ab3caeb66f13c97413e738592ec7fef7e0", size = 219672 },
     { url = "https://files.pythonhosted.org/packages/fb/4b/ed448931f973f363b4dbf38e86907a2d62cde961176fb938926b63106a38/rpds_py-0.23.0-cp313-cp313t-win_amd64.whl", hash = "sha256:f46d53a6a37383eca41a111df0e9993399a60e9e1e2110f467fddc5de4a43b68", size = 235568 },
+]
+
+[[package]]
+name = "s3transfer"
+version = "0.11.4"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "botocore" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/0f/ec/aa1a215e5c126fe5decbee2e107468f51d9ce190b9763cb649f76bb45938/s3transfer-0.11.4.tar.gz", hash = "sha256:559f161658e1cf0a911f45940552c696735f5c74e64362e515f333ebed87d679", size = 148419 }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/86/62/8d3fc3ec6640161a5649b2cddbbf2b9fa39c92541225b33f117c37c5a2eb/s3transfer-0.11.4-py3-none-any.whl", hash = "sha256:ac265fa68318763a03bf2dc4f39d5cbd6a9e178d81cc9483ad27da33637e320d", size = 84412 },
 ]
 
 [[package]]


### PR DESCRIPTION
Adding boto3 dependency to make Amazon Bedrock example work out of the box.